### PR TITLE
Some improvements/corrections

### DIFF
--- a/leOS.cpp
+++ b/leOS.cpp
@@ -177,9 +177,9 @@ uint8_t leOS::setTask(void (*userTask)(void), uint8_t tempStatus, unsigned long 
             tasks[tempI].taskIsActive = tempStatus;
             if (tempStatus == SCHEDULED) { 
 				if (taskInterval == NULL) {
-					tasks[_numTasks].plannedTask = _counterMs + tasks[tempI].userTasksInterval;
+					tasks[tempI].plannedTask = _counterMs + tasks[tempI].userTasksInterval;
 				} else {
-					tasks[_numTasks].plannedTask = _counterMs + taskInterval;
+					tasks[tempI].plannedTask = _counterMs + taskInterval;
 				}
 			}
             break;


### PR DESCRIPTION
First I think I found something that is a bug (as far as I can see). When you modify a task, it makes sense to increment a the number of tasks? The task is present on the list...

The next two are only suggestions (accept it if you want :) ):
- First, on the task scheduler function (timer handler) when you execute a function that is time consuming the next time that you execute the task it will have the execution time accumulated plus the scheduling time. Will my suggestion that does not happen.
- Second, on the setTask method, when used to resume a task (or use separately) if the task is modified to any state other than PAUSED the task will be executed on the next timer overflow. With the suggestion that I made the task will be executed only when the task interval elapsed. I change this behavior on my port to PIC microcontrollers because I prefer that way, as I said it only a suggestion.
