### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,18 +4,18 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-leOS    KEYWORD1
+leOS	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-addTask KEYWORD2
+addTask	KEYWORD2
 modifyTask	KEYWORD2
-pauseTask   KEYWORD2
-removeTask  KEYWORD2
-restartTask KEYWORD2
-getTaskStatus   KEYWORD2
+pauseTask	KEYWORD2
+removeTask	KEYWORD2
+restartTask	KEYWORD2
+getTaskStatus	KEYWORD2
 haltScheduler	KEYWORD2
 restartScheduler	KEYWORD2
 
@@ -23,8 +23,8 @@ restartScheduler	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-PAUSED  LITERAL1
-SCHEDULED   LITERAL1
-ONETIME LITERAL1
-SCHEDULED_IMMEDIATESTART    LITERAL1
+PAUSED	LITERAL1
+SCHEDULED	LITERAL1
+ONETIME	LITERAL1
+SCHEDULED_IMMEDIATESTART	LITERAL1
 IMMEDIATESTART	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords